### PR TITLE
Fix a typo involving package LICENSE

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -3,7 +3,7 @@ local autograd = require 'autograd.main'
 
 -- Meta info
 autograd.VERSION = '0.1'
-autograd.LICENSE = 'MIT'
+autograd.LICENSE = 'Apache 2.0'
 
 -- Sub packages:
 autograd.nn.AutoModule = require 'autograd.auto.AutoModule'


### PR DESCRIPTION
torch-autograd is distributed under the Apache 2.0 License. However, one of the lines of code references the MIT license instead.