### PR TITLE
Just one possible fix for Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,6 @@ for i=1,n do
    -- Backward
    local gradOutput = autoMseCriterion:backward(output, target)
    local gradInput = autoModel:backward(input, gradOutput)
-   autoModel:accGradParameters(input, gradOutput)
    for i=1,#autoParams do
       autoParams[i]:add(-lr, autoGradParams[i])
    end


### PR DESCRIPTION
First of all thanks for this wonderful tool and opensource!

Just one quick thing. I am not so sure on this line of code from one example in README file:
```lua
local gradInput = autoModel:backward(input, gradOutput)
autoModel:accGradParameters(input, gradOutput)
```

Since the `autoModel` is a `nn.Sequential()`, I think the `autoModel:backward()` function has already called the function `autoModel:accGradParameters()`, as shown in [Module.lua](https://github.com/torch/nn/blob/master/Module.lua#L30-L31) .

Therefore is it still necessary to call one extra `accGradParameter()` after `backward()`? Maybe `autograd` is different so it still requires this extra call? If not maybe we could just remove this line?

Thanks again.