### PR TITLE
Parameter free wrap

### DIFF
--- a/src/nnwrapper.lua
+++ b/src/nnwrapper.lua
@@ -232,7 +232,7 @@ local function functionalize(input)
 
    else
       -- input is assumed to be a module:
-      local mod = input
+      -- local mod = input
       local nnObject = input
       local params = nnObject:parameters()
 

--- a/src/nnwrapper.lua
+++ b/src/nnwrapper.lua
@@ -234,6 +234,7 @@ local function functionalize(input)
       -- input is assumed to be an instantiated module
       local nnObject = input
       local hasParamFn, params = pcall(nnObject.parameters, nnObject)
+      params = params or {}
       if not hasParamFn or #params == 0 then 
          params = {}
          hasParamFn = false

--- a/test/test.lua
+++ b/test/test.lua
@@ -1258,6 +1258,10 @@ local tests = {
      NNFunc_WrapWithoutParams = function()
       -- We should be able to wrap modules that don't have params.
       local tanh = autograd.functionalize(nn.Tanh())
+      local a = torch.eye(3)
+      -- Should run
+      tester:assertTensorEq(torch.tanh(a), autograd.nn.Tanh()(a), 1e-8)
+      tester:assertTensorEq(torch.tanh(a), tanh(a), 1e-8)
       local loss = autograd.functionalize(nn.MSECriterion())
 
      end,

--- a/test/test.lua
+++ b/test/test.lua
@@ -1254,6 +1254,14 @@ local tests = {
 
         end
      end,
+
+     -- NNFunc_WrapWithoutParams = function()
+     --  -- We should be able to wrap modules that don't have params.
+     --  local tanh = autograd.functionalize(nn.Tanh())
+     --  local loss = autograd.functionalize(nn.MSECriterion())
+
+     -- end,
+
 }
 
 local function prefixTests(pf, t, skip)

--- a/test/test.lua
+++ b/test/test.lua
@@ -1256,10 +1256,8 @@ local tests = {
      end,
 
      NNFunc_WrapWithoutParams = function()
-      -- We should be able to wrap modules that don't have params.
       local tanh = autograd.functionalize(nn.Tanh())
       local a = torch.eye(3)
-      -- Should run
       tester:assertTensorEq(torch.tanh(a), autograd.nn.Tanh()(a), 1e-8)
       tester:assertTensorEq(torch.tanh(a), tanh(a), 1e-8)
       local loss = autograd.functionalize(nn.MSECriterion())

--- a/test/test.lua
+++ b/test/test.lua
@@ -1255,12 +1255,12 @@ local tests = {
         end
      end,
 
-     -- NNFunc_WrapWithoutParams = function()
-     --  -- We should be able to wrap modules that don't have params.
-     --  local tanh = autograd.functionalize(nn.Tanh())
-     --  local loss = autograd.functionalize(nn.MSECriterion())
+     NNFunc_WrapWithoutParams = function()
+      -- We should be able to wrap modules that don't have params.
+      local tanh = autograd.functionalize(nn.Tanh())
+      local loss = autograd.functionalize(nn.MSECriterion())
 
-     -- end,
+     end,
 
 }
 


### PR DESCRIPTION
Previously `autograd.functionalize(nn.Tanh())(myTensor)` did not work, because Tanh had no parameters, and that wasn't handled.

So now, if you explicitly functionalize a module, here's the calling conventions (which differ from the auto-functionalized calling conventions right now! We should discuss)

**Non-autofunctionalized nn modules (now working for parameterless modules)**

```lua
-- module with parameters
linearFn, linearParams = autograd.functionalize(nn.Linear(10,10))
out = linearFn(linearParams, torch.rand(10))

-- module without parameters
tanhFn = autograd.functionalize(nn.Tanh())
out = tanhFn(torch.rand(10))
```

This is opposed to the auto-functoinalized code, which requires that the user instantiate the parameters, and have them be named properly.

**Auto-functionalized modules (always worked with parameterless modules**

```lua
-- Module with parameters
linearFn = grad.nn.Linear(100, 50)
linearParams = {
   W = torch.randn(50,100), -- note: Parameters are transposed (nn convention for nn.Linear).
   B = torch.randn(50),         --          the user is responsible for getting this correct!
}                                           --          params are split, and always assumed to be W and b
-- This is natural for nn vets, but unfortunate that user is responsible for knowing correct order
linear(torch.randn(1,100), params.W, params.B) 

-- module without parameters
tanhFn = grad.nn.Tanh()
out = acts1(torch.randn(1,100))
```

Outside of this PR, I would suggest that we standardize on one way of doing things. I'm not sure what's best, but I think returning the params, already initialized, is a lot easier. The downside of that is that the params are not named, so it's unclear what they are. This is really only a problem if we're doing per-parameter group learning rates, or applying parameter-specific learning, like weight decay. 

If we returned the params, and found a way to name them intelligently, then we might be able to provide a standardized utility for doing good initializations. 