### PR TITLE
Nnfunc update

### DIFF
--- a/benchmark/benchmark.lua
+++ b/benchmark/benchmark.lua
@@ -180,6 +180,7 @@ local tests = {
          lin,params.lin = d.nn.Linear(100,10)
          local lsm = d.nn.LogSoftMax()
          local lossf = d.nn.ClassNLLCriterion()
+         params = d.util.cast(params, ttype)
 
          local f = function(params, x, y)
             local h = lin(params.lin, x)
@@ -312,6 +313,7 @@ local tests = {
          tanh = d.nn.Tanh()
          lin2,params.lin2 = d.nn.Linear(1000,10)
          lsm = d.nn.LogSoftMax()
+         params = d.util.cast(params, ttype)
 
          local f = function(params, x, y)
             local h1 = tanh( lin1(params.lin1, x) )
@@ -380,6 +382,7 @@ local tests = {
          lin2,params.lin2 = d.nn.Linear(1000,10)
          lsm = d.nn.LogSoftMax()
          lossf = d.nn.ClassNLLCriterion()
+         params = d.util.cast(params, ttype)
 
          local f = function(params, x, y)
             local h1 = tanh( lin1(params.lin1, x) )
@@ -587,6 +590,7 @@ local tests = {
          lin2,params.lin2 = d.nn.Linear(1000,10)
          lsm = d.nn.LogSoftMax()
          lossf = d.nn.ClassNLLCriterion()
+         params = d.util.cast(params, ttype)
 
          local f = function(params, x, y)
             local h1 = tanh( lin1(params.lin1, x) )
@@ -661,6 +665,7 @@ local tests = {
          l3,params.l3 = d.nn.Linear(13*13*32,10)
          lsm = d.nn.LogSoftMax()
          lossf = d.nn.ClassNLLCriterion()
+         params = d.util.cast(params, ttype)
 
          local f = function(params, x, y)
             local h1 = m1( t1( c1(params.c1, x) ) )
@@ -894,6 +899,7 @@ local tests = {
          lin2,params.lin2 = d.nn.Linear(200,10)
          lsm = d.nn.LogSoftMax()
          lossf = d.nn.ClassNLLCriterion()
+         params = d.util.cast(params, ttype)
 
          local f = function(params, x, y)
             local h1 = lstm1(params.lstm1, x)

--- a/benchmark/benchmark.lua
+++ b/benchmark/benchmark.lua
@@ -175,21 +175,18 @@ local tests = {
       end
 
       do
-         local lin = d.nn.Linear(100,10)
+         local lin
+         local params = {}
+         lin,params.lin = d.nn.Linear(100,10)
          local lsm = d.nn.LogSoftMax()
          local lossf = d.nn.ClassNLLCriterion()
 
          local f = function(params, x, y)
-            local h = lin(x, params.W, params.b)
+            local h = lin(params.lin, x)
             local yhat = lsm(h)
             local loss = lossf(yhat, y)
             return loss
          end
-
-         local params = {
-            W = tensor(10, 100):normal(.01),
-            b = tensor(10):zero(),
-         }
 
          -- force allocs
          local df = d(f)
@@ -309,24 +306,20 @@ local tests = {
       end
 
       do
-         local lin1 = d.nn.Linear(100,1000)
-         local tanh = d.nn.Tanh()
-         local lin2 = d.nn.Linear(1000,10)
-         local lsm = d.nn.LogSoftMax()
+         local lin1,tanh,lin2,lsm
+         local params = {}
+         lin1,params.lin1 = d.nn.Linear(100,1000)
+         tanh = d.nn.Tanh()
+         lin2,params.lin2 = d.nn.Linear(1000,10)
+         lsm = d.nn.LogSoftMax()
 
          local f = function(params, x, y)
-            local h1 = tanh( lin1(x, params.W1, params.b1) )
-            local h2 = lin2(h1, params.W2, params.b2)
+            local h1 = tanh( lin1(params.lin1, x) )
+            local h2 = lin2(params.lin2, h1)
             local yhat = lsm(h2)
             local loss = -torch.sum(torch.narrow(yhat, 1, y, 1))
             return loss
          end
-         local params = {
-            W1 = tensor(1000, 100):normal(.01),
-            b1 = tensor(1000):zero(),
-            W2 = tensor(10, 1000):normal(.01),
-            b2 = tensor(10):zero(),
-         }
 
          -- force allocs
          local df = d(f)
@@ -380,25 +373,21 @@ local tests = {
       end
 
       do
-         local lin1 = d.nn.Linear(100,1000)
-         local tanh = d.nn.Tanh()
-         local lin2 = d.nn.Linear(1000,10)
-         local lsm = d.nn.LogSoftMax()
-         local lossf = d.nn.ClassNLLCriterion()
+         local lin1, tanh, lin2, lsm, lossf
+         local params = {}
+         lin1,params.lin1 = d.nn.Linear(100,1000)
+         tanh = d.nn.Tanh()
+         lin2,params.lin2 = d.nn.Linear(1000,10)
+         lsm = d.nn.LogSoftMax()
+         lossf = d.nn.ClassNLLCriterion()
 
          local f = function(params, x, y)
-            local h1 = tanh( lin1(x, params.W1, params.b1) )
-            local h2 = lin2(h1, params.W2, params.b2)
+            local h1 = tanh( lin1(params.lin1, x) )
+            local h2 = lin2(params.lin2, h1)
             local yhat = lsm(h2)
             local loss = lossf(yhat, y)
             return loss
          end
-         local params = {
-            W1 = tensor(1000, 100):normal(.01),
-            b1 = tensor(1000):zero(),
-            W2 = tensor(10, 1000):normal(.01),
-            b2 = tensor(10):zero(),
-         }
 
          -- force allocs
          local df = d(f)
@@ -591,25 +580,21 @@ local tests = {
       end
 
       do
-         local lin1 = d.nn.Linear(1000,1000)
-         local tanh = d.nn.Tanh()
-         local lin2 = d.nn.Linear(1000,10)
-         local lsm = d.nn.LogSoftMax()
-         local lossf = d.nn.ClassNLLCriterion()
+         local lin1,tanh,lin2,lsm,lossf
+         local params = {}
+         lin1,params.lin1 = d.nn.Linear(1000,1000)
+         tanh = d.nn.Tanh()
+         lin2,params.lin2 = d.nn.Linear(1000,10)
+         lsm = d.nn.LogSoftMax()
+         lossf = d.nn.ClassNLLCriterion()
 
          local f = function(params, x, y)
-            local h1 = tanh( lin1(x, params.W1, params.b1) )
-            local h2 = lin2(h1, params.W2, params.b2)
+            local h1 = tanh( lin1(params.lin1, x) )
+            local h2 = lin2(params.lin2, h1)
             local yhat = lsm(h2)
             local loss = lossf(yhat, y)
             return loss
          end
-         local params = {
-            W1 = tensor(1000, 1000):normal(.01),
-            b1 = tensor(1000):normal(.01),
-            W2 = tensor(10, 1000):normal(.01),
-            b2 = tensor(10):normal(.01),
-         }
 
          -- force allocs
          local df = d(f)
@@ -664,33 +649,35 @@ local tests = {
       end
 
       do
-         local c1 = d.nn.SpatialConvolutionMM(3,16,5,5)
-         local t1 = d.nn.Tanh()
-         local m1 = d.nn.SpatialMaxPooling(2,2,2,2)
-         local c2 = d.nn.SpatialConvolutionMM(16,32,5,5)
-         local t2 = d.nn.Tanh()
-         local m2 = d.nn.SpatialMaxPooling(2,2,2,2)
-         local r = d.nn.Reshape(13*13*32)
-         local l3 = d.nn.Linear(13*13*32,10)
-         local lsm = d.nn.LogSoftMax()
-         local lossf = d.nn.ClassNLLCriterion()
+         local c1,t1,m1,c2,t2,m2,r,l3,lsm,lossf
+         local params = {}
+         c1,params.c1 = d.nn.SpatialConvolutionMM(3,16,5,5)
+         t1 = d.nn.Tanh()
+         m1 = d.nn.SpatialMaxPooling(2,2,2,2)
+         c2,params.c2 = d.nn.SpatialConvolutionMM(16,32,5,5)
+         t2 = d.nn.Tanh()
+         m2 = d.nn.SpatialMaxPooling(2,2,2,2)
+         r = d.nn.Reshape(13*13*32)
+         l3,params.l3 = d.nn.Linear(13*13*32,10)
+         lsm = d.nn.LogSoftMax()
+         lossf = d.nn.ClassNLLCriterion()
 
          local f = function(params, x, y)
-            local h1 = m1( t1( c1(x, params.W1, params.b1) ) )
-            local h2 = m2( t2( c2(h1, params.W2, params.b2) ) )
-            local h3 = l3(r(h2), params.W3, params.b3)
+            local h1 = m1( t1( c1(params.c1, x) ) )
+            local h2 = m2( t2( c2(params.c2, h1) ) )
+            local h3 = l3(params.l3, r(h2))
             local yhat = lsm(h3)
             local loss = lossf(yhat, y)
             return loss
          end
-         local params = {
-            W1 = tensor(16, 3*5*5):normal(.01),
-            b1 = tensor(16):zero(),
-            W2 = tensor(32, 16*5*5):normal(.01),
-            b2 = tensor(32):zero(),
-            W3 = tensor(10, 32*13*13):normal(.01),
-            b3 = tensor(10):zero(),
-         }
+         -- local params = {
+         --    W1 = tensor(16, 3*5*5):normal(.01),
+         --    b1 = tensor(16):zero(),
+         --    W2 = tensor(32, 16*5*5):normal(.01),
+         --    b2 = tensor(32):zero(),
+         --    W3 = tensor(10, 32*13*13):normal(.01),
+         --    b3 = tensor(10):zero(),
+         -- }
 
          -- force allocs
          local df = d(f)
@@ -812,23 +799,21 @@ local tests = {
       end
 
       do
-         local lstm1,params = d.model.RecurrentLSTMNetwork({
+         local lstm1
+         local params = {}
+         lstm1,params.lstm1 = d.model.RecurrentLSTMNetwork({
             inputFeatures = 100,
             hiddenFeatures = 200,
             outputType = 'last',
          })
-         local lin2 = d.nn.Linear(200,10)
-         local lsm = d.nn.LogSoftMax()
-         local lossf = d.nn.ClassNLLCriterion()
-
-         table.insert(params, {
-            W = tensor(10,200),
-            b = tensor(10),
-         })
+         local lin2,lsm,lossf
+         lin2,params.lin2 = d.nn.Linear(200,10)
+         lsm = d.nn.LogSoftMax()
+         lossf = d.nn.ClassNLLCriterion()
 
          local f = function(params, x, y)
-            local h1 = lstm1(params[1], x)
-            local h2 = lin2(h1, params[2].W, params[2].b)
+            local h1 = lstm1(params.lstm1, x)
+            local h2 = lin2(params.lin2, h1)
             local yhat = lsm(h2)
             local loss = lossf(yhat, y)
             return loss
@@ -898,23 +883,21 @@ local tests = {
       end
 
       do
-         local lstm1,params = d.model.RecurrentLSTMNetwork({
+         local lstm1
+         local params = {}
+         lstm1,params.lstm1 = d.model.RecurrentLSTMNetwork({
             inputFeatures = 100,
             hiddenFeatures = 200,
             outputType = 'last',
          })
-         local lin2 = d.nn.Linear(200,10)
-         local lsm = d.nn.LogSoftMax()
-         local lossf = d.nn.ClassNLLCriterion()
-
-         table.insert(params, {
-            W = tensor(10,200),
-            b = tensor(10),
-         })
+         local lin2, lsm, lossf
+         lin2,params.lin2 = d.nn.Linear(200,10)
+         lsm = d.nn.LogSoftMax()
+         lossf = d.nn.ClassNLLCriterion()
 
          local f = function(params, x, y)
-            local h1 = lstm1(params[1], x)
-            local h2 = lin2(h1, params[2].W, params[2].b)
+            local h1 = lstm1(params.lstm1, x)
+            local h2 = lin2(params.lin2, h1)
             local yhat = lsm(h2)
             local loss = lossf(yhat, y)
             return loss

--- a/examples/train-mnist-autoencoder.lua
+++ b/examples/train-mnist-autoencoder.lua
@@ -26,9 +26,9 @@ function predict(params, input)
    local h2 = util.sigmoid(h1 * params.W[2] + torch.expand(params.B[2], torch.size(input, 1), torch.size(params.B[2], 2)))
    local h3 = util.sigmoid(h2 * params.W[3] + torch.expand(params.B[3], torch.size(input, 1), torch.size(params.B[3], 2)))
    -- Decoder
-   local h4 = util.sigmoid(h3 * torch.transpose(params.W[3]) + torch.expand(params.B[4], torch.size(input, 1), torch.size(params.B[4], 2)))
-   local h5 = util.sigmoid(h4 * torch.transpose(params.W[2]) + torch.expand(params.B[5], torch.size(input, 1), torch.size(params.B[5], 2)))
-   local out = util.sigmoid(h5 * torch.transpose(params.W[1]) + torch.expand(params.B[6], torch.size(input, 1), torch.size(params.B[6], 2)))
+   local h4 = util.sigmoid(h3 * torch.t(params.W[3]) + torch.expand(params.B[4], torch.size(input, 1), torch.size(params.B[4], 2)))
+   local h5 = util.sigmoid(h4 * torch.t(params.W[2]) + torch.expand(params.B[5], torch.size(input, 1), torch.size(params.B[5], 2)))
+   local out = util.sigmoid(h5 * torch.t(params.W[1]) + torch.expand(params.B[6], torch.size(input, 1), torch.size(params.B[6], 2)))
 
    return out
 end

--- a/examples/train-mnist-cnn.lua
+++ b/examples/train-mnist-cnn.lua
@@ -18,13 +18,13 @@ local reshape = grad.nn.Reshape(1,32,32)
 
 local conv1, acts1, pool1, conv2, acts2, pool2, flatten, linear
 local params = {}
-conv1,params.conv1 = grad.nn.SpatialConvolutionMM(1, 16, 5, 5)
+conv1, params.conv1 = grad.nn.SpatialConvolutionMM(1, 16, 5, 5)
 acts1 = grad.nn.Tanh()
 pool1 = grad.nn.SpatialMaxPooling(2, 2, 2, 2)
 
-conv2,params.conv2 = grad.nn.SpatialConvolutionMM(16, 16, 5, 5)
+conv2, params.conv2 = grad.nn.SpatialConvolutionMM(16, 16, 5, 5)
 acts2 = grad.nn.Tanh()
-pool2,params.pool2 = grad.nn.SpatialMaxPooling(2, 2, 2, 2)
+pool2, params.pool2 = grad.nn.SpatialMaxPooling(2, 2, 2, 2)
 
 flatten = grad.nn.Reshape(16*5*5)
 linear,params.linear = grad.nn.Linear(16*5*5, 10)
@@ -61,13 +61,16 @@ for epoch = 1,100 do
       local y = torch.view(trainData.y[i], 1, 10)
 
       -- Grads:
+      print("Preparam type: " .. params.conv1[1]:type())
       local grads, loss, prediction = df(params,x,y)
 
       -- Update weights and biases
-      for i=1,2 do
-         params.conv1[i] = params.conv1[i] - grads.conv1[i] * 0.01
-         params.conv2[i] = params.conv2[i] - grads.conv2[i] * 0.01
-         params.linear[i] = params.linear[i] - grads.linear[i] * 0.01
+      print("Param type: " .. params.conv1[1]:type())
+      print("Grad type: " .. grads.conv1[1]:type())
+      for iparam=1,2 do
+         params.conv1[iparam] = params.conv1[iparam] - grads.conv1[iparam] * 0.01
+         params.conv2[iparam] = params.conv2[iparam] - grads.conv2[iparam] * 0.01
+         params.linear[iparam] = params.linear[iparam] - grads.linear[iparam] * 0.01
       end
 
       -- Log performance:

--- a/examples/train-mnist-cnn.lua
+++ b/examples/train-mnist-cnn.lua
@@ -16,22 +16,24 @@ local predict,f,params
 -- for CNNs, we rely on efficient nn-provided primitives:
 local reshape = grad.nn.Reshape(1,32,32)
 
-local conv1 = grad.nn.SpatialConvolutionMM(1, 16, 5, 5)
-local acts1 = grad.nn.Tanh()
-local pool1 = grad.nn.SpatialMaxPooling(2, 2, 2, 2)
+local conv1, acts1, pool1, conv2, acts2, pool2, flatten, linear
+local params = {}
+conv1,params.conv1 = grad.nn.SpatialConvolutionMM(1, 16, 5, 5)
+acts1 = grad.nn.Tanh()
+pool1 = grad.nn.SpatialMaxPooling(2, 2, 2, 2)
 
-local conv2 = grad.nn.SpatialConvolutionMM(16, 16, 5, 5)
-local acts2 = grad.nn.Tanh()
-local pool2 = grad.nn.SpatialMaxPooling(2, 2, 2, 2)
+conv2,params.conv2 = grad.nn.SpatialConvolutionMM(16, 16, 5, 5)
+acts2 = grad.nn.Tanh()
+pool2,params.pool2 = grad.nn.SpatialMaxPooling(2, 2, 2, 2)
 
-local flatten = grad.nn.Reshape(16*5*5)
-local linear = grad.nn.Linear(16*5*5, 10)
+flatten = grad.nn.Reshape(16*5*5)
+linear,params.linear = grad.nn.Linear(16*5*5, 10)
 
 -- Define our network
 function predict(params, input, target)
-   local h1 = pool1(acts1(conv1(reshape(input), params.W[1], params.B[1])))
-   local h2 = pool2(acts2(conv2(h1, params.W[2], params.B[2])))
-   local h3 = linear(flatten(h2), params.W[3], params.B[3])
+   local h1 = pool1(acts1(conv1(params.conv1, reshape(input))))
+   local h2 = pool2(acts2(conv2(params.conv2, h1)))
+   local h3 = linear(params.linear, flatten(h2))
    local out = util.logSoftMax(h3)
    return out
 end
@@ -45,23 +47,10 @@ end
 
 
 -- Define our parameters
--- [-1/sqrt(#output), 1/sqrt(#output)]
 torch.manualSeed(0)
-local W1 = torch.FloatTensor(16,1*5*5):uniform(-1/math.sqrt(16),1/math.sqrt(16))
-local B1 = torch.FloatTensor(16):fill(0)
-local W2 = torch.FloatTensor(16,16*5*5):uniform(-1/math.sqrt(16),1/math.sqrt(16))
-local B2 = torch.FloatTensor(16):fill(0)
-local W3 = torch.FloatTensor(#classes,16*5*5):uniform(-1/math.sqrt(#classes),1/math.sqrt(#classes))
-local B3 = torch.FloatTensor(#classes):fill(0)
-
--- Trainable parameters:
-params = {
-   W = {W1, W2, W3},
-   B = {B1, B2, B3},
-}
 
 -- Get the gradients closure magically:
-local df = grad(f, { optimize = true })
+local df = grad(f, {optimize=true})
 
 -- Train a neural network
 for epoch = 1,100 do
@@ -75,9 +64,10 @@ for epoch = 1,100 do
       local grads, loss, prediction = df(params,x,y)
 
       -- Update weights and biases
-      for i=1,#params.W do
-         params.W[i] = params.W[i] - grads.W[i] * 0.01
-         params.B[i] = params.B[i] - grads.B[i] * 0.01
+      for i=1,2 do
+         params.conv1[i] = params.conv1[i] - grads.conv1[i] * 0.01
+         params.conv2[i] = params.conv2[i] - grads.conv2[i] * 0.01
+         params.linear[i] = params.linear[i] - grads.linear[i] * 0.01
       end
 
       -- Log performance:

--- a/examples/train-mnist-cnn.lua
+++ b/examples/train-mnist-cnn.lua
@@ -29,6 +29,9 @@ pool2, params.pool2 = grad.nn.SpatialMaxPooling(2, 2, 2, 2)
 flatten = grad.nn.Reshape(16*5*5)
 linear,params.linear = grad.nn.Linear(16*5*5, 10)
 
+-- Cast the parameters
+params = grad.util.cast(params, 'float')
+
 -- Define our network
 function predict(params, input, target)
    local h1 = pool1(acts1(conv1(params.conv1, reshape(input))))
@@ -61,12 +64,9 @@ for epoch = 1,100 do
       local y = torch.view(trainData.y[i], 1, 10)
 
       -- Grads:
-      print("Preparam type: " .. params.conv1[1]:type())
       local grads, loss, prediction = df(params,x,y)
 
       -- Update weights and biases
-      print("Param type: " .. params.conv1[1]:type())
-      print("Grad type: " .. grads.conv1[1]:type())
       for iparam=1,2 do
          params.conv1[iparam] = params.conv1[iparam] - grads.conv1[iparam] * 0.01
          params.conv2[iparam] = params.conv2[iparam] - grads.conv2[iparam] * 0.01

--- a/src/gradfuns.lua
+++ b/src/gradfuns.lua
@@ -405,7 +405,7 @@ overload.module("torch", torch, function(module)
    })
    module.gradient("transpose", {
       function(g, ans, x, d1, d2)
-         return torch.t(g, d1, d2)
+         return torch.transpose(g, d1, d2)
       end,
       function(g, ans, x, d1, d2)
          return nil

--- a/src/gradfuns.lua
+++ b/src/gradfuns.lua
@@ -133,7 +133,7 @@ operators.mul = {
       if not isTensorA then
          return torch.sum(elemwiseMul(g, B))
       elseif isTensorB and torch.nDimension(B) == 2 then
-         return g * torch.transpose(B)
+         return g * torch.t(B)
       elseif isTensorA and torch.nDimension(A) == 2 then
          if not isTensorB then
             return elemwiseMul(g, B)
@@ -151,7 +151,7 @@ operators.mul = {
       if not isTensorB then
          return torch.sum(elemwiseMul(g, A))
       elseif isTensorA and torch.nDimension(A) == 2 then
-         return torch.transpose(A) * g
+         return torch.t(A) * g
       elseif isTensorB and torch.nDimension(B) == 2 then
          if not isTensorA then
             return elemwiseMul(g, A)
@@ -233,10 +233,10 @@ overload.module("torch", torch, function(module)
    module.gradient("ger", {
       -- Only takes 1D vectors as input
       function(g, ans, x, y) return g * y end,
-      function(g, ans, x, y) return torch.transpose(g) * x end
+      function(g, ans, x, y) return torch.t(g) * x end
    })
    module.gradient("inverse", {
-      function(g, ans, x) return -((torch.transpose(ans) * g) * torch.transpose(ans)) end,
+      function(g, ans, x) return -((torch.t(ans) * g) * torch.t(ans)) end,
    })
    module.gradient("exp", {
       function(g, ans, x) return elemwiseMul(ans, g) end,
@@ -404,9 +404,20 @@ overload.module("torch", torch, function(module)
       end
    })
    module.gradient("transpose", {
-      function(g, ans, x)
-         return torch.transpose(g)
+      function(g, ans, x, d1, d2)
+         return torch.t(g, d1, d2)
+      end,
+      function(g, ans, x, d1, d2)
+         return nil
+      end,
+      function(g, ans, x, d1, d2)
+         return nil
       end
+   })
+   module.gradient("t", {
+      function(g, ans, x)
+         return torch.t(g)
+      end,
    })
    module.gradient("long", {
       function(g, ans, x)

--- a/src/model/AlexNet.lua
+++ b/src/model/AlexNet.lua
@@ -1,0 +1,94 @@
+local sequence = require 'autograd.model.common'.sequence
+local NeuralNetwork = require 'autograd.model.NeuralNetwork'
+local SpatialNetwork = require 'autograd.model.SpatialNetwork'
+
+
+-- The ImageNet architecture for AlexNet would be set with the following options:
+-- http://arxiv.org/pdf/1404.5997v2.pdf
+-- https://github.com/eladhoffer/ImageNet-Training/blob/2cd055056082c05f7a7f5392fb7897c706cdb38a/Models/AlexNet_BN.lua
+-- convOpt = {
+   -- kernelSize = 3, -- NOTE: currently don't support per-layer kernel sizes. If we did, it'd be {11,5,3,3,3}
+   -- hiddenFeatures = {64,192,384,256,256},
+   -- batchNormalization = true,
+   -- padding = 2, -- NOTE: currently don't support per-layer paddings. If we did, it'd be {2,2,1,1,1}
+   -- dropoutProb = 0,
+   -- activations = 'ReLU',
+   -- inputStride = 1, -- NOTE: currently don't supported per-layer inputStrides. If we did, it'd be {4,1,1,1,1}
+   -- poolings = {3,3,3,3,3} -- We don't set kW/H and dW/H separately.
+-- }
+mlpOpt = {
+   hiddenFeatures = {4096,4096,1000},
+   batchNormalization = true,
+   dropoutProbs = {0.5,0.5,0},
+   classifier = true,
+   activations = "ReLU",
+}
+
+return function(imageDepth, imageHeight, imageWidth, convOpt, mlpOpt, params, layers, layer2params)
+
+   -- Convolution options
+   --------------------------------------------
+   convOpt = convOpt or {}
+   if convOpt.inputFeatures then
+      print("Input features set will be overridden with the imageDepth value provided: " .. tostring(imageDepth))
+   end
+   convOpt.inputFeatures = imageDepth
+   convOpt.kernelSize = convOpt.kernelSize or 5
+   if convOpt.kernelSizes then
+      error("Currently, per-layer kernel sizes are not supported")
+   end
+   convOpt.padding = convOpt.padding
+   if convOpt.paddings then
+      error("Currently, per-layer paddings are not supported")
+   end
+   convOpt.hiddenFeatures = convOpt.hiddenFeatures or {16,32,64}
+   convOpt.batchNormalization = convOpt.batchNormalization or false
+   convOpt.dropoutProb = convOpt.dropoutProb or 0
+   convOpt.dropoutProbs = convOpt.dropoutProbs or {}
+   convOpt.activations = convOpt.activations or 'ReLU'
+   convOpt.poolings = convOpt.poolings or {1,1,1}
+   convOpt.inputStride = convOpt.inputStride or 1
+   convOpt.cuda = convOpt.cuda or false
+
+   -- MLP options
+   --------------------------------------------
+   mlpOpt = mlpOpt or {}
+   if mlpOpt.inputFeatures then
+      error("Input features on the fully-connected layers cannot be manually set, do not specify")
+   end
+   mlpOpt.hiddenFeatures = mlpOpt.hiddenFeatures or {100,2}
+   mlpOpt.batchNormalization = mlpOpt.batchNormalization or false
+   mlpOpt.dropoutProb = mlpOpt.dropoutProb or 0
+   mlpOpt.dropoutProbs = mlpOpt.dropoutProbs or {}
+   mlpOpt.activations = mlpOpt.activations or 'ReLU'
+   mlpOpt.classifier = mlpOpt.classifier or true -- classifier by default.
+   mlpOpt.cuda = mlpOpt.cuda or false
+   mlpOpt = mlpOpt or {}
+
+   if (mlpOpt.cuda and not convOpt.cuda) or (not mlpOpt.cuda and convOpt.cuda) then
+      print("")
+      print("CUDA set on one, but not both of spatial and fully-connected layers. Setting all to CUDA.")
+      mlpOpt.cuda = true
+      convOpt.cuda = true
+   end
+
+   -- container
+   layers = layers or {}
+   params = params or {}
+   layer2params = layer2params or {}
+
+   -- Build convnet layers
+   local sp,params,layers = SpatialNetwork(convOpt, params, layers, layer2params)
+
+   -- Figure out convolution net output size (dependent on image size)
+   local testInput = torch.randn(1, imageDepth, imageHeight, imageWidth):typeAs(params[1][1]):contiguous()
+   local res = sp(params, testInput)
+   mlpOpt.inputFeatures = res:size(2)*res:size(3)*res:size(4)
+
+   -- Set up fully-connected layers to accept convolutional layer output
+   local fn,params,layers = NeuralNetwork(mlpOpt, params, layers, layer2params)
+
+   return sequence(layers, layer2params), params, layers
+
+end
+

--- a/src/model/NeuralNetwork.lua
+++ b/src/model/NeuralNetwork.lua
@@ -1,6 +1,6 @@
 local sequence = require 'autograd.model.common'.sequence
-
 local nn = require('autograd.main').nn
+hasCudnn, cudnn = pcall(require, 'cudnn')
 
 local function NeuralLayer(opt, params, layers, layer2params)
    -- options:
@@ -10,36 +10,37 @@ local function NeuralLayer(opt, params, layers, layer2params)
    local batchNormalization = opt.batchNormalization or false
    local dropoutProb = opt.dropoutProb or 0
    local activations = opt.activations
+   local cuda = opt.cuda or false
 
    -- container
    layers = layers or {}
    params = params or {}
    layer2params = layer2params or {}
 
-   -- dropout:
+   -- Dropout
+   --------------------------------------
    if dropoutProb > 0 then
-      table.insert(layers, nn.Dropout(dropoutProb))
+      table.insert(layers, nn.SpatialDropout(dropoutProb) )
    end
 
-   -- linear layer:
-   table.insert(layers, nn.Linear(inputFeatures, outputFeatures))
-   table.insert(params, {
-      W = torch.zeros(outputFeatures, inputFeatures),
-      b = torch.zeros(outputFeatures),
-   })
+   -- Fully-connected layer
+   --------------------------------------
+   local l,p = nn.Linear(inputFeatures, outputFeatures)
+   table.insert(layers, l)
+   table.insert(params, p)
    layer2params[#layers] = #params
 
-   -- batch normalization:
+   -- Batch normalization
+   --------------------------------------
    if batchNormalization then
-      table.insert(layers, nn.BatchNormalization(outputFeatures))
-      table.insert(params, {
-         W = torch.zeros(outputFeatures),
-         b = torch.zeros(outputFeatures),
-      })
+      local l,p = nn.SpatialBatchNormalization(outputFeatures)
+      table.insert(layers, l)
+      table.insert(params, p)
       layer2params[#layers] = #params
    end
 
-   -- activations:
+   -- Activations
+   --------------------------------------
    if opt.activations then
       table.insert(layers, nn[activations]())
    end
@@ -58,6 +59,7 @@ return function(opt, params, layers, layer2params)
    local dropoutProbs = opt.dropoutProbs or {}
    local activations = opt.activations or 'ReLU'
    local classifier = opt.classifier or false
+   local cuda = opt.cuda or false
 
    -- container
    layers = layers or {}
@@ -79,6 +81,7 @@ return function(opt, params, layers, layer2params)
          dropoutProb = dropoutProbs[i] or dropoutProb,
          activations = activations,
          batchNormalization = batchNormalization,
+         cuda = cuda,
       }, params, layers, layer2params)
       inputFeatures = hiddens
    end

--- a/src/model/SpatialNetwork.lua
+++ b/src/model/SpatialNetwork.lua
@@ -1,6 +1,11 @@
 local sequence = require 'autograd.model.common'.sequence
-local nn = require('autograd.main').nn
-hasCudnn, cudnn = pcall(require, 'cudnn')
+local hasCudnn, cudnn = pcall(require, 'cudnn')
+local functionalize = require('autograd.nnwrapper').functionalize
+local cast = require('autograd.util').cast
+if hasCudnn then
+   cudnn = functionalize('cudnn')
+end
+local nn = functionalize('nn')
 
 local function SpatialLayer(opt, params, layers, layer2params)
    -- options:
@@ -16,6 +21,14 @@ local function SpatialLayer(opt, params, layers, layer2params)
    local inputStride = opt.inputStride or 1
    local cuda = opt.cuda or false
 
+   -- Set up modules
+   local SpatialConvolution = nn.SpatialConvolutionMM
+   local SpatialMaxPooling = nn.SpatialMaxPooling
+   if cuda and hasCudnn then
+      SpatialConvolution = cudnn.SpatialConvolution
+      SpatialMaxPooling = cudnn.SpatialMaxPooling
+   end
+
    -- container
    layers = layers or {}
    params = params or {}
@@ -29,7 +42,7 @@ local function SpatialLayer(opt, params, layers, layer2params)
 
    -- Convolution
    --------------------------------------
-   local l,p = nn.SpatialConvolutionMM(inputFeatures, outputFeatures, kernelSize, kernelSize, inputStride, inputStride, padding, padding)
+   local l,p = SpatialConvolution(inputFeatures, outputFeatures, kernelSize, kernelSize, inputStride, inputStride, padding, padding)
    table.insert(layers, l)
    table.insert(params, p)
    layer2params[#layers] = #params
@@ -46,16 +59,21 @@ local function SpatialLayer(opt, params, layers, layer2params)
    -- Activations
    --------------------------------------
    if opt.activations then
-      table.insert(layers, nn[activations]())
+      local activation
+      if hasCudnn and cuda then
+         activation = cudnn[activations]()
+      else
+         activation = nn[activations]()
+      end
+      table.insert(layers, activation)
    end
 
    -- Pooling
    --------------------------------------
    if pooling > 1 then
-      table.insert(layers, nn.SpatialMaxPooling(pooling, pooling))
+      table.insert(layers, SpatialMaxPooling(pooling, pooling))
    end
 
-   -- layers
    return sequence(layers, layer2params), params, layers
 end
 
@@ -96,6 +114,13 @@ return function(opt, params, layers, layer2params)
       inputFeatures = hiddens
       inputStride = 1
    end
+
+   -- Type cast, if CUDA
+   --------------------------------------
+   if cuda then
+      params = cast(params, "cuda")
+   end
+
 
    -- layers
    return sequence(layers, layer2params), params, layers

--- a/src/model/common.lua
+++ b/src/model/common.lua
@@ -5,7 +5,7 @@ return {
          for i,layer in ipairs(layers) do
             local paramsi = layer2params[i]
             if paramsi then
-               input = layer(input, params[paramsi].W, params[paramsi].b)
+               input = layer(params[paramsi], input)
             else
                input = layer(input)
             end

--- a/src/model/init.lua
+++ b/src/model/init.lua
@@ -4,6 +4,7 @@ local model = {
    SpatialNetwork = require 'autograd.model.SpatialNetwork',
    RecurrentNetwork = require 'autograd.model.RecurrentNetwork',
    RecurrentLSTMNetwork = require 'autograd.model.RecurrentLSTMNetwork',
+   AlexNet = require 'autograd.model.AlexNet'
 }
 
 return model

--- a/src/nnwrapper.lua
+++ b/src/nnwrapper.lua
@@ -185,8 +185,8 @@ local function wrapModuleWithParams(nnObject)
       local modelParams, modelGradParams = nnObject:parameters()
       for i,p in ipairs(modelParams) do
          if p ~= params[i] then
-            -- NOTE: casting params here
-            params[i] = params[i]:type(lastType)
+            -- NOTE: need a better error message
+            -- if there's a type mismatch
             p:view(params[i], params[i]:size())
          end
       end
@@ -197,18 +197,13 @@ local function wrapModuleWithParams(nnObject)
       -- NOTE: Is this necessary if it's done forward?
       nnObject, lastType = updateType(nnObject, lastType, getInputType(x))
       local modelParams, modelGradParams = nnObject:parameters()
-      print(getInputType(x))
-      print(modelParams[1]:type())
       for i,p in ipairs(modelParams) do
          if p ~= params[i] then
-            params[i] = params[i]:type(lastType)
             p:view(params[i], params[i]:size())
          end
       end
       nnObject:zeroGradParameters()
       local gradInput = nnObject:backward(x, g)
-      print("Grad type: " .. modelGradParams[1]:type())
-      print("Grad input: " .. gradInput:type())
       return {modelGradParams, gradInput}
    end
 

--- a/src/nnwrapper.lua
+++ b/src/nnwrapper.lua
@@ -38,7 +38,13 @@ local function isModule(nnObject)
    if mt then
       local mmt = getmetatable(mt)
       if mmt then
-         local t = mmt.__typename
+         local t
+         local mmmt = getmetatable(mmt)
+         if mmmt then
+            t = mmmt.__typename
+         else
+            t = mmt.__typename
+         end
          if t == "nn.Module" or t == "nn.Sequential" or t == "nn.Container" or t == "nn.Threshold" then
             isModule = true
          end
@@ -281,6 +287,7 @@ functionalizePackage = function(packageName)
       -- Iterate through every module in the package,
       -- and functionalize it
       local map = {}
+
       for modName, nnClass in pairs(mod) do
          if isModule(nnClass) or isCriterion(nnClass) then
             map[modName] = function(...)

--- a/src/nnwrapper.lua
+++ b/src/nnwrapper.lua
@@ -136,7 +136,7 @@ local function wrapModuleWithoutParams(nnObject)
       nnObject, lastType = updateType(nnObject, lastType, getInputType(x))
       nnObject:zeroGradParameters()
       local gradInput = nnObject:backward(x, g)
-      return gradInput -- {modelGradParams, gradInput}
+      return gradInput
    end
 
    local fn = function(x)
@@ -197,13 +197,18 @@ local function wrapModuleWithParams(nnObject)
       -- NOTE: Is this necessary if it's done forward?
       nnObject, lastType = updateType(nnObject, lastType, getInputType(x))
       local modelParams, modelGradParams = nnObject:parameters()
+      print(getInputType(x))
+      print(modelParams[1]:type())
       for i,p in ipairs(modelParams) do
          if p ~= params[i] then
-            p:view(params[i]:type(lastType), params[i]:size())
+            params[i] = params[i]:type(lastType)
+            p:view(params[i], params[i]:size())
          end
       end
       nnObject:zeroGradParameters()
       local gradInput = nnObject:backward(x, g)
+      print("Grad type: " .. modelGradParams[1]:type())
+      print("Grad input: " .. gradInput:type())
       return {modelGradParams, gradInput}
    end
 

--- a/src/nnwrapper.lua
+++ b/src/nnwrapper.lua
@@ -39,7 +39,7 @@ local function isModule(nnObject)
       local mmt = getmetatable(mt)
       if mmt then
          local t = mmt.__typename
-         if t == "nn.Module" or t == "nn.Sequential" or t == "nn.Container" then
+         if t == "nn.Module" or t == "nn.Sequential" or t == "nn.Container" or t == "nn.Threshold" then
             isModule = true
          end
       end

--- a/src/support.lua
+++ b/src/support.lua
@@ -42,7 +42,11 @@ torch.isSameSizeAs = function(A, B)
    return A:isSameSizeAs(B)
 end
 
-torch.transpose = function(A)
+torch.transpose = function(A, d1, d2)
+   return A:transpose(d1,d2)
+end
+
+torch.t = function(A)
    return A:t()
 end
 

--- a/src/util.lua
+++ b/src/util.lua
@@ -1,6 +1,29 @@
 -- Utilities
 local util = {}
 
+local cast
+function cast(tableOfParams, typeName)
+   -- Some nice aliases
+   if typeName == "float" then typeName = "torch.FloatTensor" end
+   if typeName == "double" then typeName = "torch.DoubleTensor" end
+   if typeName == "cuda" then typeName = "torch.CudaTensor" end
+
+   -- Recursively cast
+   local out = {}
+   for key,value in pairs(tableOfParams) do
+      if torch.isTensor(value) then
+         out[key] = value:type(typeName)
+      elseif type(value) == "table" then
+         out[key] = cast(value,typeName)
+      else
+         out[key] = value
+      end
+   end
+   return out
+end
+
+util.cast = cast
+
 function util.oneHot(labels, n)
    --[[
    Assume labels is a 1D tensor of contiguous class IDs, starting at 1.

--- a/test/test.lua
+++ b/test/test.lua
@@ -849,6 +849,7 @@ local tests = {
    end,
 
    NNFunc_Float = function()
+
       -- More complex model:
       local inputSize = 100
       local hiddenSize = 50
@@ -858,9 +859,9 @@ local tests = {
       local x = torch.FloatTensor(inputSize):normal()
 
       -- nn modules:
-      local linear1,pLinear1 = autograd.nn.Linear(inputSize, hiddenSize)
+      local linear1, pLinear1 = autograd.nn.Linear(inputSize, hiddenSize)
       local acts1 = autograd.nn.Tanh()
-      local linear2,pLinear2 = autograd.nn.Linear(hiddenSize, outputSize)
+      local linear2, pLinear2 = autograd.nn.Linear(hiddenSize, outputSize)
       local acts2 = autograd.nn.Tanh()
       params = {linear1 = pLinear1, linear2 = pLinear2, x = x}
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -950,8 +950,8 @@ local tests = {
          return loss,pred
       end
 
-      params[1].W:normal(0,0.01)
-      params[2].W:normal(0,0.01)
+      params[1][1]:normal(0,0.01)
+      params[2][1]:normal(0,0.01)
 
       local i = torch.randn(100)
       local t = torch.Tensor({1,0})
@@ -960,10 +960,10 @@ local tests = {
       local grads = autograd(loss)(params, i, t)
 
       tester:asserteq(type(l), 'number', 'loss should be a scalar')
-      tester:asserteq(grads[1].W:dim(), 2, 'weights for layer 2 have incorrect dims')
-      tester:asserteq(grads[1].b:dim(), 1, 'biases for layer 2 have incorrect dims')
-      tester:asserteq(grads[2].W:dim(), 2, 'weights for layer 4 have incorrect dims')
-      tester:asserteq(grads[2].b:dim(), 1, 'biases for layer 4 have incorrect dims')
+      tester:asserteq(grads[1][1]:dim(), 2, 'weights for layer 2 have incorrect dims')
+      tester:asserteq(grads[1][2]:dim(), 1, 'biases for layer 2 have incorrect dims')
+      tester:asserteq(grads[2][1]:dim(), 2, 'weights for layer 4 have incorrect dims')
+      tester:asserteq(grads[2][2]:dim(), 1, 'biases for layer 4 have incorrect dims')
 
       -- Gradcheck
       tester:assert(gradcheck(loss, params, i, t), 'incorrect gradients')
@@ -995,10 +995,10 @@ local tests = {
       end
 
       local params = {params1, params2}
-      params[1][1].W:normal(0,0.01)
-      params[1][2].W:normal(0,0.01)
-      params[2][1].W:normal(0,0.01)
-      params[2][2].W:normal(0,0.01)
+      params[1][1][1]:normal(0,0.01)
+      params[1][2][1]:normal(0,0.01)
+      params[2][1][1]:normal(0,0.01)
+      params[2][2][1]:normal(0,0.01)
 
       local i = torch.randn(3,8,8)
       local t = torch.randn(2)

--- a/test/test.lua
+++ b/test/test.lua
@@ -1303,8 +1303,8 @@ local function prefixTests(pf, t, skip)
 end
 
 -- Run tests:
--- autograd.optimize(true)
--- tester:add(prefixTests("Optimized_", tests, { })):run()
+autograd.optimize(true)
+tester:add(prefixTests("Optimized_", tests, { })):run()
 autograd.optimize(false)
 tester = totem.Tester()
 tester:add(prefixTests("Direct_", tests, { AutoModule = true, DebuggerDivZero = true })):run()

--- a/test/test.lua
+++ b/test/test.lua
@@ -130,7 +130,6 @@ local tests = {
    NNWrapperTableInput = function()
       local A = torch.eye(10)
       local B = torch.eye(10):mul(3)
-      local mmModule = nn.MM()
       local mmFn = autograd.nn.MM()
 
       local fn = function(inputs)
@@ -866,22 +865,28 @@ local tests = {
 
       -- Trainable parameters:
       local x = torch.FloatTensor(inputSize):normal()
-      local W1 = torch.FloatTensor(hiddenSize,inputSize):normal()
-      local b1 = torch.FloatTensor(hiddenSize):normal()
-      local W2 = torch.FloatTensor(outputSize,hiddenSize):normal()
-      local b2 = torch.FloatTensor(outputSize):normal()
-      local params = {W1=W1, b1=b1, W2=W2, b2=b2, x=x}
+      -- local W1 = torch.FloatTensor(hiddenSize,inputSize):normal()
+      -- local b1 = torch.FloatTensor(hiddenSize):normal()
+      -- local W2 = torch.FloatTensor(outputSize,hiddenSize):normal()
+      -- local b2 = torch.FloatTensor(outputSize):normal()
+      -- local params = {W1=W1, b1=b1, W2=W2, b2=b2, x=x}
+      -- local params = {}
 
       -- nn modules:
-      local linear1 = autograd.nn.Linear(inputSize, hiddenSize)
+      local linear1,pLinear1 = autograd.nn.Linear(inputSize, hiddenSize)
       local acts1 = autograd.nn.Tanh()
-      local linear2 = autograd.nn.Linear(hiddenSize, outputSize)
+
+      print(linear1(pLinear1, x))
+      os.exit()
+
+      local linear2,pLinear2 = autograd.nn.Linear(hiddenSize, outputSize)
       local acts2 = autograd.nn.Tanh()
+      params = {linear1 = pLinear1, linear2 = pLinear2}
 
       -- nn version:
       local function mlp(params)
-         local h1 = acts1(linear1(params.x, params.W1, params.b1))
-         local h2 = acts2(linear2(h1, params.W2, params.b2))
+         local h1 = acts1(linear1(params.linear1, params.x))
+         local h2 = acts2(linear2(params.linear2,params.x))
          local o = torch.sum(h2)
          return o
       end

--- a/test/test.lua
+++ b/test/test.lua
@@ -274,7 +274,7 @@ local tests = {
 
    Transpose = function()
       local fn = function(inputs)
-         return torch.sum(torch.transpose(inputs.x))
+         return torch.sum(torch.t(inputs.x))
       end
 
       -- Check grads:

--- a/test/test.lua
+++ b/test/test.lua
@@ -736,23 +736,21 @@ local tests = {
       -- Tested params:
       local inputSize = 100
       local outputSize = 50
-      local W = torch.Tensor(outputSize,inputSize):normal()
-      local b = torch.Tensor(outputSize):normal()
       local x = torch.Tensor(inputSize):normal()
-      local params = {W=W, b=b, x=x}
 
       -- nn modules:
-      local linear1 = autograd.nn.Linear(inputSize, outputSize)
+      local linear1, linearParams = autograd.nn.Linear(inputSize, outputSize)
+      params = {linearParams=linearParams, x=x}
 
       -- nn version:
       local function f_nn(params)
-         local funcout = linear1(params.x, params.W, params.b)
+         local funcout = linear1(params.linearParams, params.x)
          return torch.sum(funcout)
       end
 
       -- autograd version:
       local function f_autograd(params)
-         return torch.sum(params.W * params.x + params.b)
+         return torch.sum(params.linearParams[1] * params.x + params.linearParams[2])
       end
 
       -- Get the NN predictions
@@ -766,13 +764,13 @@ local tests = {
       local grad_autograd = g_autograd(params)
 
       -- Check
-      tester:asserteq((grad_nn.W-grad_autograd.W):abs():max(), 0, "Incorrect gradients")
+      tester:asserteq((grad_nn.linearParams[1]-grad_autograd.linearParams[1]):abs():max(), 0, "Incorrect gradients")
       tester:asserteq((grad_nn.x-grad_autograd.x):abs():max(), 0, "Incorrect gradients")
 
       -- Run a 2nd time - gradients should get recomputed:
-      W:normal()
-      b:normal()
-      x:normal()
+      params.linearParams[1]:normal()
+      params.linearParams[2]:normal()
+      params.x:normal()
 
       -- Get the NN predictions
       local pred_nn = f_nn(params)
@@ -785,7 +783,7 @@ local tests = {
       local grad_autograd = g_autograd(params)
 
       -- Check
-      tester:asserteq((grad_nn.W-grad_autograd.W):abs():max(), 0, "Incorrect gradients")
+      tester:asserteq((grad_nn.linearParams[1]-grad_autograd.linearParams[1]):abs():max(), 0, "Incorrect gradients")
       tester:asserteq((grad_nn.x-grad_autograd.x):abs():max(), 0, "Incorrect gradients")
    end,
 
@@ -795,24 +793,21 @@ local tests = {
       local hiddenSize = 50
       local outputSize = 10
 
-      -- Trainable parameters:
-      local x = torch.Tensor(inputSize):normal()
-      local W1 = torch.Tensor(hiddenSize,inputSize):normal()
-      local b1 = torch.Tensor(hiddenSize):normal()
-      local W2 = torch.Tensor(outputSize,hiddenSize):normal()
-      local b2 = torch.Tensor(outputSize):normal()
-      local params = {W1=W1, b1=b1, W2=W2, b2=b2, x=x}
+      -- nn modules and their parameters:
+      local params = {}
+      local linear1, linear2, acts1, acts2
+      linear1, params.linear1 = autograd.nn.Linear(inputSize, hiddenSize)
+      acts1 = autograd.nn.Tanh()
+      linear2,params.linear2 = autograd.nn.Linear(hiddenSize, outputSize)
+      acts2 = autograd.nn.Tanh()
 
-      -- nn modules:
-      local linear1 = autograd.nn.Linear(inputSize, hiddenSize)
-      local acts1 = autograd.nn.Tanh()
-      local linear2 = autograd.nn.Linear(hiddenSize, outputSize)
-      local acts2 = autograd.nn.Tanh()
+      -- input data
+      params.x = torch.Tensor(inputSize):normal()
 
       -- nn version:
       local function mlp(params)
-         local h1 = acts1(linear1(params.x, params.W1, params.b1))
-         local h2 = acts2(linear2(h1, params.W2, params.b2))
+         local h1 = acts1(linear1(params.linear1, params.x))
+         local h2 = acts2(linear2(params.linear2, h1))
          local o = torch.sum(h2)
          return o
       end
@@ -826,25 +821,21 @@ local tests = {
    end,
 
    NNFunc_CNN = function()
-      -- Trainable parameters:
-      local x = torch.Tensor(3, 8, 8):normal()
-      local W1 = torch.Tensor(16, 3*3*3):normal()
-      local b1 = torch.Tensor(16):normal()
-      local W2 = torch.Tensor(10, 16*8*8):normal()
-      local b2 = torch.Tensor(10):normal()
-      local params = {W1=W1, b1=b1, W2=W2, b2=b2, x=x}
+      -- Start params with input data:
+      local params = {x=torch.Tensor(3, 8, 8):normal()}
 
       -- nn modules:
-      local conv1 = autograd.nn.SpatialConvolutionMM(3, 16, 3, 3, 1, 1, 1, 1)
-      local acts1 = autograd.nn.Tanh()
-      local flatten = autograd.nn.Reshape(16*8*8)
-      local linear2 = autograd.nn.Linear(16*8*8, 10)
-      local acts2 = autograd.nn.Tanh()
+      local conv1, acts1, flatten, linear2, acts2
+      conv1,params.conv1 = autograd.nn.SpatialConvolutionMM(3, 16, 3, 3, 1, 1, 1, 1)
+      acts1 = autograd.nn.Tanh()
+      flatten = autograd.nn.Reshape(16*8*8)
+      linear2, params.linear2 = autograd.nn.Linear(16*8*8, 10)
+      acts2 = autograd.nn.Tanh()
 
       -- nn version:
       local function cnn(params)
-         local h1 = acts1(conv1(params.x, params.W1, params.b1))
-         local h2 = acts2(linear2(flatten(h1), params.W2, params.b2))
+         local h1 = acts1(conv1(params.conv1, params.x))
+         local h2 = acts2(linear2(params.linear2, flatten(h1)))
          local o = torch.sum(h2)
          return o
       end
@@ -863,30 +854,20 @@ local tests = {
       local hiddenSize = 50
       local outputSize = 10
 
-      -- Trainable parameters:
+      -- Input data
       local x = torch.FloatTensor(inputSize):normal()
-      -- local W1 = torch.FloatTensor(hiddenSize,inputSize):normal()
-      -- local b1 = torch.FloatTensor(hiddenSize):normal()
-      -- local W2 = torch.FloatTensor(outputSize,hiddenSize):normal()
-      -- local b2 = torch.FloatTensor(outputSize):normal()
-      -- local params = {W1=W1, b1=b1, W2=W2, b2=b2, x=x}
-      -- local params = {}
 
       -- nn modules:
       local linear1,pLinear1 = autograd.nn.Linear(inputSize, hiddenSize)
       local acts1 = autograd.nn.Tanh()
-
-      print(linear1(pLinear1, x))
-      os.exit()
-
       local linear2,pLinear2 = autograd.nn.Linear(hiddenSize, outputSize)
       local acts2 = autograd.nn.Tanh()
-      params = {linear1 = pLinear1, linear2 = pLinear2}
+      params = {linear1 = pLinear1, linear2 = pLinear2, x = x}
 
       -- nn version:
       local function mlp(params)
          local h1 = acts1(linear1(params.linear1, params.x))
-         local h2 = acts2(linear2(params.linear2,params.x))
+         local h2 = acts2(linear2(params.linear2,h1))
          local o = torch.sum(h2)
          return o
       end
@@ -896,10 +877,10 @@ local tests = {
       local pred = mlp(params)
 
       -- Check grads:
-      tester:asserteq(torch.typename(grads.W1), 'torch.FloatTensor', 'incorrect type')
-      tester:asserteq(torch.typename(grads.W2), 'torch.FloatTensor', 'incorrect type')
-      tester:asserteq(torch.typename(grads.b1), 'torch.FloatTensor', 'incorrect type')
-      tester:asserteq(torch.typename(grads.b2), 'torch.FloatTensor', 'incorrect type')
+      tester:asserteq(torch.typename(grads.linear1[1]), 'torch.FloatTensor', 'incorrect type')
+      tester:asserteq(torch.typename(grads.linear1[2]), 'torch.FloatTensor', 'incorrect type')
+      tester:asserteq(torch.typename(grads.linear2[1]), 'torch.FloatTensor', 'incorrect type')
+      tester:asserteq(torch.typename(grads.linear2[2]), 'torch.FloatTensor', 'incorrect type')
    end,
 
    NNFunc_DynamicWrap = function()
@@ -1322,8 +1303,8 @@ local function prefixTests(pf, t, skip)
 end
 
 -- Run tests:
-autograd.optimize(true)
-tester:add(prefixTests("Optimized_", tests, { })):run()
+-- autograd.optimize(true)
+-- tester:add(prefixTests("Optimized_", tests, { })):run()
 autograd.optimize(false)
 tester = totem.Tester()
 tester:add(prefixTests("Direct_", tests, { AutoModule = true, DebuggerDivZero = true })):run()

--- a/test/test.lua
+++ b/test/test.lua
@@ -863,7 +863,10 @@ local tests = {
       local acts1 = autograd.nn.Tanh()
       local linear2, pLinear2 = autograd.nn.Linear(hiddenSize, outputSize)
       local acts2 = autograd.nn.Tanh()
-      params = {linear1 = pLinear1, linear2 = pLinear2, x = x}
+      params = autograd.util.cast({
+         linear1 = pLinear1, 
+         linear2 = pLinear2, 
+         x = x}, "float")
 
       -- nn version:
       local function mlp(params)


### PR DESCRIPTION
This PR unifies the functionalize API. Now, whole-package functionalization and module functionalization are equivalent.

```lua
-- Pre-functionalized nn package
f, params = autograd.nn.Linear(10,10)

-- Functionalized nn module
f, params = autograd.functionalize(nn.Linear(10,10))

-- Both use the same codepath to perform the functionalization now
```

There are two calls:
https://github.com/twitter/torch-autograd/blob/nnfunc-update/src/nnwrapper.lua#L256-L294
`functionalize()` and `functionalizePackage()`. 
If you call `functionalize` with a string value, it will forward it to funcitonalizePackage.
Now, parameter-free modules, like criterions, thresholds and non-linearities, are functionalized like so:

```lua
f = autograd.functionalize(nn.Tanh())
```

Modules with parameters, including modules, containers and sequences, are functionalized like so:
```lua
f, params = autograd.functionalize(nn.Linear(10,10))

-- Here's the contents of params, although you do not need to initialize them
params = {torch.Tensor(10,10), torch.Tensor(10)} -- weights and biases, in that order

-- If you need to cast the parameters to another type, there is now a utility:
params = autograd.util.cast(params, "float") -- or "torch.FloatTensor", "torch.CudaTensor", "cuda", or any other torch type.

-- A helpful pattern if you have many functionalized modules is to vacuum their parameters 
-- into a single table
local f1, f2, params
parmas = {}
f1, params.f1 = autograd.functionalize(nn.Linear(100,10))
f2, params.f2 = autograd.functionalize(nn.Linear(10,10))

-- And then, if you need to cast this nested table of parameters, cast() will still work.
params = autograd.util.cast(params, 'cuda') -- cuda is aliased to torch.CudaTensor
```

Please check for speed regressions (none on my system), and I would really like comments on the API, if you think there's room for simplification or clarification.

cc @clementfarabet @nkoumchatzky @luketwitter 