### PR TITLE
Fixed error when finding gradient of function containing scalar-scalar multiply

### DIFF
--- a/src/gradfuns.lua
+++ b/src/gradfuns.lua
@@ -139,7 +139,7 @@ operators.mul = {
       local isTensorA = torch.isTensor(A)
       local isTensorB = torch.isTensor(B)
 
-      if not isTensorA then
+      if not isTensorA and isTensorB then
          return torch.sum(elemwiseMul(g, B))
       elseif isTensorB and torch.nDimension(B) == 2 then
          return g * torch.transpose(B)
@@ -157,7 +157,7 @@ operators.mul = {
       local isTensorA = torch.isTensor(A)
       local isTensorB = torch.isTensor(B)
       
-      if not isTensorB then
+      if not isTensorB and isTensorA then
          return torch.sum(elemwiseMul(g, A))
       elseif isTensorA and torch.nDimension(A) == 2 then
          return torch.transpose(A) * g

--- a/test/test.lua
+++ b/test/test.lua
@@ -1313,7 +1313,7 @@ local tests = {
       local params = { W = torch.randn(5,5) }
       -- this line should not raise an error
       local grads, loss = df(params)
-	  tester:assert(gradcheck(f, {W=params.W}), 'incorrect gradients')
+      tester:assert(gradcheck(f, {W=params.W}), 'incorrect gradients')
    end,
 }
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -1304,6 +1304,17 @@ local tests = {
       tester:assert(gradcheck(f, input, target), 'incorrect gradients')
    end,
 
+   ScalarMul = function()
+      -- Tests that functions that use scalar multiply do not cause an error
+      function f(params)
+        return torch.sum(params.W) * 0.4
+      end
+      local df = autograd(f)
+      local params = { W = torch.randn(5,5) }
+      -- this line should not raise an error
+      local grads, loss = df(params)
+	  tester:assert(gradcheck(f, {W=params.W}), 'incorrect gradients')
+   end,
 }
 
 local function prefixTests(pf, t, skip)


### PR DESCRIPTION
For details of the error see issue 73: https://github.com/twitter/torch-autograd/issues/73

This error seems to appear whenever the function for which we want to find the gradient contains a scalar-scalar multiply. This affects any loss function with a weighting parameter (eg. the lambda parameter for L2 weight decay, or the beta parameter for inducing sparse activations with KL-divergence)

The example train-mnist-autoencoder.lua is affected by this since it makes use of L2 weight decay.

As far as I can see, the error is caused by the fact that operators.mul in gradfuns.lua makes the assumption that if A is not a tensor, then B is a tensor. This is not the case with scalar-scalar multiplication. Changing the condition to check that B is also a tensor means that in the scalar-scalar case it falls right through to the final else.

The pull request includes a unit test which exercises this case.

Edit: added slightly more detail.