### PR TITLE
fixed assertion in GradGrad test. Also added SimpleGradGrad test

### DIFF
--- a/test/test.lua
+++ b/test/test.lua
@@ -1418,6 +1418,23 @@ local tests = {
       tester:assert(gradcheck(f3to4, {x=torch.randn(3,3,3)}), "Incorrect gradient")
    end,
 
+   ZeroGrad = function()
+      --the output of this function does not depend on params, so its grad should be uniformly zero
+      local innerFn = function(params, x, y)
+         return torch.norm(torch.add(x,y))
+      end
+
+      local dneuralNet = autograd(innerFn)
+
+      local numFeatures = 5
+      local testParams = torch.randn(numFeatures)
+      local x = torch.randn(numFeatures)
+      local y = torch.randn(1)[1]
+
+      local analyticalGrad = testParams:clone():zero()
+      local numericalGrad = dneuralNet(testParams,x,y)
+      tester:assertTensorEq(analyticalGrad,numericalGrad,1e-8,'analytical and numerical solution do not match')
+   end,
 
    SimpleGradGrad = function()
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -1418,6 +1418,45 @@ local tests = {
       tester:assert(gradcheck(f3to4, {x=torch.randn(3,3,3)}), "Incorrect gradient")
    end,
 
+
+   SimpleGradGrad = function()
+
+      local innerFn = function(params, x, y)
+         local yHat = params*x
+         local squaredLoss = (y - yHat)
+         return squaredLoss
+      end
+
+      --autodiff
+      local dneuralNet = autograd(innerFn)
+
+      --the outer function computes the sum of the gradient of the neural network. Therefore, differentiating yields the sum of each column of the Hessian
+      local outerFn = function(params_2,x,y)
+         local grad = dneuralNet(params_2,x,y)
+         return torch.sum(grad)
+      end
+
+      --autodiff solution for sum of each column of Hessian
+      local ddf = autograd(outerFn)
+
+
+      local numFeatures = 1
+
+      local testParams = torch.randn(numFeatures)
+      local x = torch.randn(numFeatures)
+      local y = torch.randn(1)[1]
+
+      local analyticalGrad = x:clone():mul(-1)
+      local numericalGrad = dneuralNet(testParams,x,y)
+
+      tester:assertTensorEq(analyticalGrad,numericalGrad,1e-8,'analytical and numerical solution do not match')
+
+      local analyticalGradGrad = x:clone():zero()
+      local numericalGradGrad = ddf(testParams,x,y)
+
+      tester:assertTensorEq(analyticalGradGrad,numericalGradGrad,1e-8,'analytical and numerical solution do not match')
+   end,
+   
    GradGrad = function()
 
       local numFeatures = 5
@@ -1455,8 +1494,8 @@ local tests = {
 
       --analytical expression
       hessian = torch.ger(x,x):mul(2)
-      analyticalGradGrad = torch.sum(hessian,1)
-      tester:assertTensorEq(analyticalGrad,numericalGrad,1e-8,'analytical and numerical solution do not match')
+      analyticalGradGrad = torch.sum(hessian,2)
+      tester:assertTensorEq(analyticalGradGrad,numericalGradGrad,1e-8,'analytical and numerical solution do not match')
    end,
 
    Assignment = function()


### PR DESCRIPTION
In an earlier PR, I pushed the GradGrad test. Unfortunately, there was a bug in the code and it was only checking the accuracy of the first gradient with respect to an analytical solution, not the second-order gradient (it was making sure that the second order gradient could even be evaluated, which was also failing at the time of the PR). I fixed this. Unfortunately, the test is failing. I'm very sorry for the overly optimistic test, especially as the passing of this test was referred to in the recent update to README.md.

I've also added the SimpleGradGrad test, which is very simple: it's a linear function f(x,y) = y - ax. Here, the second order derivative should be uniformly 0. This is not the case (currently the autograd value is -x). This might be an easier test case to first debug the grads-of-grads stuff. 

Finally, I added ZeroGrad test, which checks that the gradient of a function f(params,x,y)  that doesn't depend on the params is uniformly 0. Right now it doesn't return the correct value, or even a value of the correct type. It might be useful to address this before SimpleGradGrad.



