### PR TITLE
Prevent infinite recursion in number operation

### DIFF
--- a/src/support.lua
+++ b/src/support.lua
@@ -67,21 +67,24 @@ local numberMetatable = {
       if type(a) == "number"  then
          return b + a
       else
-         return a + b
+         error("attempt to perform an addition between a number and a " ..
+            type(a) .. ".", 2)
       end
    end,
    __sub = function(a,b)
       if type(a) == "number"  then
          return -b + a
       else
-         return a - b
+         error("attempt to perform a substraction between a number and a " ..
+            type(a) .. ".", 2)
       end
    end,
    __mul = function(a,b)
       if type(a) == "number"  then
          return b * a
       else
-         return a * b
+         error("attempt to perform an multiplication between a number and a " ..
+            type(a) .. ".", 2)
       end
    end
 }

--- a/src/support.lua
+++ b/src/support.lua
@@ -67,24 +67,21 @@ local numberMetatable = {
       if type(a) == "number"  then
          return b + a
       else
-         error("attempt to perform an addition between a number and a " ..
-            type(a) .. ".", 2)
+         error("attempt to perform arithmetic on a " .. type(a) .. " value", 2)
       end
    end,
    __sub = function(a,b)
       if type(a) == "number"  then
          return -b + a
       else
-         error("attempt to perform a substraction between a number and a " ..
-            type(a) .. ".", 2)
+         error("attempt to perform arithmetic on a " .. type(a) .. " value", 2)
       end
    end,
    __mul = function(a,b)
       if type(a) == "number"  then
          return b * a
       else
-         error("attempt to perform an multiplication between a number and a " ..
-            type(a) .. ".", 2)
+         error("attempt to perform arithmetic on a " .. type(a) .. " value", 2)
       end
    end
 }


### PR DESCRIPTION
Fix #113 
So after looking more closely, the only way to be in this state ([l70](https://github.com/twitter/torch-autograd/blob/14e7f9bd79b1905295a7075e894cf850e3599357/src/support.lua#L70), [l77](https://github.com/twitter/torch-autograd/blob/14e7f9bd79b1905295a7075e894cf850e3599357/src/support.lua#L77) and [l84](https://github.com/twitter/torch-autograd/blob/14e7f9bd79b1905295a7075e894cf850e3599357/src/support.lua#L84)) is if `a` is not a number,  `b` is and `a` does not have an `__add` method. Since the original number addition can only work with numbers, we should always raise an error when getting to this state.

For clarity I changed the position in the stack of the error (as is done in the original number operation). The new error message is:
```lua
local function add(a,b)
    return a + b
end

local ok, res = pcall(add, nil, 2)
print(res)
-- foo.lua:2: attempt to perform arithmetic on local 'a' (a nil value) 

require 'autograd'

local ok, res = pcall(add, nil, 2)
print(res)
-- foo.lua:2: attempt to perform arithmetic on a nil value	
```