### PR TITLE
Add scalar support to gradcheck

### DIFF
--- a/src/gradcheck.lua
+++ b/src/gradcheck.lua
@@ -7,83 +7,117 @@ local perturbation = 1e-6
 -- Threshold:
 local threshold = 1e-5
 
--- Find grad:
-local function findGrad(ref, x, dst)
-   for k,v in pairs(ref) do
-      if v == x then
-         return dst[k]
-      elseif type(v) == 'table' then
-         local res = findGrad(ref[k], x, dst[k])
-         if res then return res end
-      end
-   end
-end
-
 -- Compute grads with bprop:
-local function jacobianFromAutograd(func, inputs, var)
+local function jacobianFromAutograd(func, inputs, key)
    -- Autograd:
    local df = autograd(func)
    local grads = df(table.unpack(inputs))
    local gradsVerify = df(table.unpack(inputs))
 
    -- Find grad:
-   local g = findGrad(inputs[1], var, grads)
-   local gVerify = findGrad(inputs[1], var, gradsVerify)
-   local err = (g - gVerify):abs():max()
+   local g = autograd.util.nestedGet(grads, key)
+   local gVerify = autograd.util.nestedGet(gradsVerify, key)
+   local err
+   if torch.isTensor(g) then
+      err = (g - gVerify):abs():max()
+   else
+      err = torch.abs(g - gVerify)
+   end
 
    if err ~= 0 then
       error("autograd gradient not deterministic")
    end
 
    -- Return grads:
-   return g:contiguous():view(-1):clone()
+   if torch.isTensor(g) then
+      return g:contiguous():view(-1):clone()
+   else
+      return g
+   end
 end
 
 -- Compute grads from finite differences
-local function jacobianFromFiniteDifferences(func, inputs, var)
-   -- Flat view:
-   local view = var:view(-1)
+local function jacobianFromFiniteDifferences(func, inputs, key)
+   local var = autograd.util.nestedGet(inputs[1], key)
 
-   -- Grads:
-   local grads = view:clone():zero()
+   if torch.isTensor(var) then
+      -- Flat view:
+      local view = var:view(-1)
 
-   -- Finite diffs:
-   for i = 1,view:size(1) do
+      -- Grads:
+      local grads = view:clone():zero()
+
+      -- Finite diffs:
+      for i = 1,view:size(1) do
+         -- Initial val:
+         local val = view[i]
+
+         -- Perturbate:
+         view[i] = val - perturbation/2
+         local pred1 = func(table.unpack(inputs))
+         view[i] = val + perturbation/2
+         local pred2 = func(table.unpack(inputs))
+         view[i] = val
+
+         -- Finite diff:
+         grads[i] = (pred2-pred1) / perturbation
+      end
+      -- Return grads:
+      return grads
+   else
       -- Initial val:
-      local val = view[i]
+      local val = var
 
       -- Perturbate:
-      view[i] = val - perturbation/2
+      autograd.util.nestedSet(inputs[1], key, val - perturbation/2)
       local pred1 = func(table.unpack(inputs))
-      view[i] = val + perturbation/2
+      autograd.util.nestedSet(inputs[1], key, val + perturbation/2)
       local pred2 = func(table.unpack(inputs))
-      view[i] = val
+      autograd.util.nestedSet(inputs[1], key, val)
 
       -- Finite diff:
-      grads[i] = (pred2-pred1) / perturbation
+      return (pred2-pred1) / perturbation
    end
-   -- Return grads:
-   return grads
 end
 
-local function gradcheckvar2(func, inputs, var, randomizeInput)
+local function gradcheckvar2(func, inputs, key, randomizeInput)
+   local var = autograd.util.nestedGet(inputs[1], key)
+   local isTensorVar = torch.isTensor(var)
+
    -- Random input:
    if randomizeInput then
-      var:uniform(-10,10)
+      if isTensorVar then
+         var:uniform(-10,10)
+      else
+         autograd.util.nestedSet(inputs[1], key, 20 * (math.random() - 0.5))
+         var = autograd.util.nestedGet(inputs[1], key)
+      end
    end
 
    -- Estimate grads with fprop:
-   local jacobian = jacobianFromAutograd(func, inputs, var)
+   local jacobian = jacobianFromAutograd(func, inputs, key)
    local originalLoss = func(table.unpack(inputs))
-   local noise = jacobian:view(-1):clone():zero()
-   local idx = math.random(1, noise:size(1))
+   
+   local perturbedLoss, approxPerturbed
 
-   local originalVar = var:clone()
-   noise:narrow(1,idx,1):uniform(-perturbation, perturbation)
-   var:add(torch.view(noise, var:size()))
+   if isTensorVar then
+      local noise = jacobian:view(-1):clone():zero()
+      local idx = math.random(1, noise:size(1))
+      local originalVar = var:clone()
+      noise:narrow(1,idx,1):uniform(-perturbation, perturbation)
+      var:add(torch.view(noise, var:size()))
 
-   local perturbedLoss = func(table.unpack(inputs))
-   local approxPerturbed = originalLoss + torch.dot(jacobian, noise)
+      perturbedLoss = func(table.unpack(inputs))
+      approxPerturbed = originalLoss + torch.dot(jacobian, noise)
+      var:copy(originalVar)
+   else
+      local noise = 2*perturbation*(math.random()-0.5)
+      autograd.util.nestedSet(inputs[1], key, var + noise)
+
+      perturbedLoss = func(table.unpack(inputs))
+      approxPerturbed = originalLoss + jacobian * noise
+      autograd.util.nestedSet(inputs[1], key, var)
+   end
 
    -- Error:
    local err = math.abs((perturbedLoss - approxPerturbed)) /
@@ -97,24 +131,35 @@ local function gradcheckvar2(func, inputs, var, randomizeInput)
       print('approximated perturbed loss = '..approxPerturbed)
       print('error = ' .. err)
    end
-   var:copy(originalVar)
    return pass, err
 end
 
-local function gradcheckvar(func, inputs, var, randomizeInput)
+local function gradcheckvar(func, inputs, key, randomizeInput)
+   local var = autograd.util.nestedGet(inputs[1], key)
+   local isTensorVar = torch.isTensor(var)
+
    -- Random input:
    if randomizeInput then
-      var:uniform(-1,1)
+      if isTensorVar then
+         var:uniform(-1,1)
+      else
+         autograd.util.nestedSet(inputs[1], key, 2*math.random()-1)
+      end
    end
 
    -- Estimate grads with fprop:
-   local jacobian1 = jacobianFromFiniteDifferences(func, inputs, var)
+   local jacobian1 = jacobianFromFiniteDifferences(func, inputs, key)
 
    -- Coded grads:
-   local jacobian2 = jacobianFromAutograd(func, inputs, var)
+   local jacobian2 = jacobianFromAutograd(func, inputs, key)
 
    -- Error:
-   local err = (jacobian1 - jacobian2):abs():max()
+   local err
+   if isTensorVar then
+      err = (jacobian1 - jacobian2):abs():max()
+   else
+      err = torch.abs(jacobian1 - jacobian2)
+   end
 
    -- Threhold?
    local pass = err < threshold
@@ -136,14 +181,14 @@ return function(opt)
    local function gradcheck(func, ...)
       local args = {...}
       -- get all vars:
-      local vars = autograd.util.sortedFlatten(args[1])
+      local vars, keys = autograd.util.sortedFlattenKeys(args[1])
       local max_err = 0
       local ok = true
-      for i,var in ipairs(vars) do
-         local t, err = gradcheckvar2(func, args, var, randomizeInput)
+      for i,key in ipairs(keys) do
+         local t, err = gradcheckvar2(func, args, key, randomizeInput)
          ok = ok and t
          if err > max_err then max_err = err end
-         ok = ok and gradcheckvar(func, args, var, randomizeInput)
+         ok = ok and gradcheckvar(func, args, key, randomizeInput)
       end
       print('[gradcheck2] maximum error = '..max_err)
       return ok

--- a/src/util.lua
+++ b/src/util.lua
@@ -310,6 +310,16 @@ function util.nestedGet(tbl, nestedKey, startInd)
    end
 end
 
+function util.nestedSet(tbl, nestedKey, val, startInd)
+   local startInd = startInd or 1
+   if startInd == #nestedKey then
+      tbl[nestedKey[startInd]] = val
+      return nil
+   else
+      return util.nestedSet(tbl[nestedKey[startInd]], nestedKey, val, startInd+1)
+   end
+end
+
 function util.shallowCopy(tbl)
    if type(tbl) == "table" then
       local copy = { }

--- a/src/util.lua
+++ b/src/util.lua
@@ -264,6 +264,52 @@ function util.sortedFlatten(tbl, flat, noRecurse)
    return flat
 end
 
+function util.sortedFlattenKeys(tbl, flat, flatKeys, parentKey, noRecurse)
+   flat = flat or { }
+   flatKeys = flatKeys or { }
+   parentKey = parentKey or { }
+   if type(tbl) == "table" then
+      local keys = { }
+      for k, v in pairs(tbl) do
+         keys[#keys + 1] = k
+      end
+      local ok = pcall(function()
+         return table.sort(keys)
+      end)
+      if not ok then
+         table.sort(keys, function(a, b)
+            return tostring(a) < tostring(b)
+         end)
+      end
+      for i = 1, #keys do
+         local val = tbl[keys[i]]
+         parentKey[#parentKey + 1] = keys[i]
+         if type(val) == "table" and not noRecurse then
+            util.sortedFlattenKeys(val, flat, flatKeys, parentKey)
+         else
+            flat[#flat + 1] = val
+            flatKeys[#flatKeys + 1] = util.shallowCopy(parentKey)
+         end
+         parentKey[#parentKey] = nil
+      end
+   else
+      flat[#flat + 1] = tbl
+      flatKeys[#flatKeys + 1] = util.shallowCopy(parentKey)
+   end
+
+   return flat, flatKeys
+end
+
+function util.nestedGet(tbl, nestedKey, startInd)
+   nestedKey = nestedKey or { }
+   startInd = startInd or 1
+   if startInd > #nestedKey then
+      return tbl
+   else
+      return util.nestedGet(tbl[nestedKey[startInd]], nestedKey, startInd+1)
+   end
+end
+
 function util.shallowCopy(tbl)
    if type(tbl) == "table" then
       local copy = { }


### PR DESCRIPTION
This branch adds scalar support to gradcheck. The pattern of using findGrad to locate a corresponding value inside a nested table doesn't work when the variable being searched for is a basic type. As an alternative I've added a few utilities to facilitate the access of values inside of nested tables and rewritten the functions in `src/gradcheck.lua` to accept the nested key as input rather than the variable itself (which could be a basic type).