### PR TITLE
Accumulate gradient in-place

### DIFF
--- a/src/runtime/direct/DirectTape.lua
+++ b/src/runtime/direct/DirectTape.lua
@@ -156,6 +156,8 @@ function DirectTape.gradOnly(tape, arg, argnum, allAns, gradOutput)
                if gradUpdate then
                   if thisArg.outgrad == nil or thisArg.outgrad == 0 then
                      thisArg.outgrad = gradUpdate
+                  elseif torch.isTensor(thisArg.outgrad) then
+                     thisArg.outgrad:add(gradUpdate)
                   else
                      thisArg.outgrad = thisArg.outgrad + gradUpdate
                   end


### PR DESCRIPTION
I benchmarked some of my `torch-autograd` code on CPU and noticed that 40% of the time was spent accumulating gradients. I noticed that the gradient is currently not being added in-place:
```lua
thisArg.outgrad = thisArg.outgrad + gradUpdate
```
The right hand side of this expression allocates a new tensor for the sum, and then assigns that to `thisArg.outgrad`. Using `thisArg.outgrad:add(gradUpdate)` should be faster.

When I add the gradients in-place on my Macbook (so using CPU) it uses more memory, but this is likely just because of https://github.com/torch/torch7/issues/229. When I use `jemalloc` (`DYLD_INSERT_LIBRARIES=<libs>/libjemalloc.dylib`) everything runs smoothly, and I get a significant speedup: My model runtime decreases from ~47 s to ~30 s (so ~1.55x speedup). I haven't tried this on GPU yet.