### PR TITLE
Avoid packing and then unpacking again

### DIFF
--- a/src/runtime/direct/DirectTape.lua
+++ b/src/runtime/direct/DirectTape.lua
@@ -90,8 +90,7 @@ function nodeApply(fun, gradFun, ...)
       end
       return newNode
    else
-      local values = {fun.fn(table.unpack(values))}
-      return table.unpack(values)
+      return fun.fn(table.unpack(values))
    end
 end
 


### PR DESCRIPTION
Because this function gets called so many times this actually makes a difference for me. Before the change the `nodeApply` and its child calls took 90% of the time, afterwards only 74% of the time. Not counting child calls it goes from 20% to 7%, which for my model means from 7.1s to 2.7 s (speeding things up with about ~5-10%).