### PR TITLE
Add batch norm option to LSTM.

### DIFF
--- a/src/model/RecurrentLSTMNetwork.lua
+++ b/src/model/RecurrentLSTMNetwork.lua
@@ -1,6 +1,7 @@
 -- util
 local util = require 'autograd.util'
-local grad = require 'autograd'
+local functionalize = require('autograd.nnwrapper').functionalize
+local nn = functionalize('nn')
 
 return function(opt, params)
    -- options:
@@ -22,15 +23,15 @@ return function(opt, params)
    }
    if batchNormalization then
      -- translation and scaling parameters are shared across time.
-     local lstm_bn, p_lstm_bn = grad.nn.BatchNormalization(4 * hiddenFeatures)
-     local cell_bn, p_cell_bn = grad.nn.BatchNormalization(hiddenFeatures)
+     local lstm_bn, p_lstm_bn = nn.BatchNormalization(4 * hiddenFeatures)
+     local cell_bn, p_cell_bn = nn.BatchNormalization(hiddenFeatures)
 
      layers.lstm_bn = {lstm_bn}
      layers.cell_bn = {cell_bn}
 
      for i=2,#maxBatchNormalizationLayers do
-       local lstm_bn = grad.nn.BatchNormalization(4 * hiddenFeatures)
-       local cell_bn = grad.nn.BatchNormalization(hiddenFeatures)
+       local lstm_bn = nn.BatchNormalization(4 * hiddenFeatures)
+       local cell_bn = nn.BatchNormalization(hiddenFeatures)
        layers.lstm_bn[i] = lstm_bn
        layers.cell_bn[i] = cell_bn
      end


### PR DESCRIPTION
Implements "Recurrent Batch Normalization" by Cooijmans et al. https://arxiv.org/abs/1603.09025

Some key details and outstanding issues:
- Recommended initialization for (gamma, beta) parameters is provided. Gamma needs to be < 1 for batch norm to really work in the recurrent regime. See the paper for details
- (Gamma, beta) are shared through time but each time step requires independent running avg and var estimates. This implementation uses a fixed max number of batch norm layers and reuses the last one if needed for long sequences. This can also be made adaptive during training, but I'm not sure how safe it is to add layers mid-training in autograd.
- nn.BatchNormalization layers maintain avg and var estimates as separate state that can't easily be passed to an autograd function with optimize=true. Just trying to capture layers as an upvalue doesn't seem to work with optimize=true.