### PR TITLE
Add layers argument to support reloading and fix iteration upper bound.

### DIFF
--- a/src/model/RecurrentLSTMNetwork.lua
+++ b/src/model/RecurrentLSTMNetwork.lua
@@ -3,7 +3,7 @@ local util = require 'autograd.util'
 local functionalize = require('autograd.nnwrapper').functionalize
 local nn = functionalize('nn')
 
-return function(opt, params, layers)
+return function(opt, params)
    -- options:
    opt = opt or {}
    local inputFeatures = opt.inputFeatures or 10
@@ -12,9 +12,9 @@ return function(opt, params, layers)
    local batchNormalization = opt.batchNormalization or false
    local maxBatchNormalizationLayers = opt.maxBatchNormalizationLayers or 10
 
-   -- container:
+   -- containers:
    params = params or {}
-   layers = layers or {}
+   layers = {}
 
    -- parameters:
    local p = {
@@ -45,7 +45,7 @@ return function(opt, params, layers)
    table.insert(params, p)
 
    -- function:
-   local f = function(params, x, prevState)
+   local f = function(params, x, prevState, layers)
       -- dims:
       local p = params[1] or params
       if torch.nDimension(x) == 2 then

--- a/src/model/RecurrentLSTMNetwork.lua
+++ b/src/model/RecurrentLSTMNetwork.lua
@@ -3,7 +3,7 @@ local util = require 'autograd.util'
 local functionalize = require('autograd.nnwrapper').functionalize
 local nn = functionalize('nn')
 
-return function(opt, params)
+return function(opt, params, layers)
    -- options:
    opt = opt or {}
    local inputFeatures = opt.inputFeatures or 10
@@ -29,7 +29,7 @@ return function(opt, params)
      layers.lstm_bn = {lstm_bn}
      layers.cell_bn = {cell_bn}
 
-     for i=2,#maxBatchNormalizationLayers do
+     for i=2,maxBatchNormalizationLayers do
        local lstm_bn = nn.BatchNormalization(4 * hiddenFeatures)
        local cell_bn = nn.BatchNormalization(hiddenFeatures)
        layers.lstm_bn[i] = lstm_bn


### PR DESCRIPTION
Layers passed explicitly to LSTM function to allow reloading batch norm layer parameters. Note that layers are not currently supported as arguments in optimize mode so this can only be used in direct mode. Layers also need to be switched between train/evaluate outside of the LSTM function.

Also fixed bug in iteration when making batch norm layers.