### PR TITLE
Fix locals and layer norm gradient edge case.

### DIFF
--- a/src/module/LayerNormalization.lua
+++ b/src/module/LayerNormalization.lua
@@ -30,7 +30,7 @@ return function(opt, params)
     local n = torch.size(x_in,2)
     local mean = torch.expand(torch.mean(x_in, 2), torch.size(x_in))
     local x_centered = x_in - mean
-    local std = torch.expand(torch.sqrt(torch.sum(torch.cmul(x_centered, x_centered) / n, 2)) + eps, torch.size(x_in))
+    local std = torch.expand(torch.sqrt(torch.sum(torch.cmul(x_centered, x_centered) / n, 2) + eps), torch.size(x_in))
     local x_normed = torch.cdiv(x_centered, std)
     local gain = torch.expand(p.gain, torch.size(x_in))
     local bias = torch.expand(p.bias, torch.size(x_in))

--- a/src/module/LayerNormalization.lua
+++ b/src/module/LayerNormalization.lua
@@ -4,8 +4,8 @@ return function(opt, params)
   local params = params or {}
 
   local nOutputs = opt.nOutputs or 10
-  p = {gain = torch.ones(1, nOutputs),
-       bias = torch.zeros(1, nOutputs)}
+  local p = {gain = torch.ones(1, nOutputs),
+             bias = torch.zeros(1, nOutputs)}
   table.insert(params, p)
 
   local function layer_norm(params, x, eps)

--- a/src/module/MaskedBatchNormalization.lua
+++ b/src/module/MaskedBatchNormalization.lua
@@ -6,13 +6,13 @@ return function(opt, params)
   local nOutputs = opt.nOutputs or 10
   local momentum = opt.momentum or 0.1
 
-  batchNormState = {momentum = momentum, train = 1,
-                    running_mean = torch.zeros(1, nOutputs),
-                    running_std = torch.ones(1, nOutputs)}
+  local batchNormState = {momentum = momentum, train = 1,
+                         running_mean = torch.zeros(1, nOutputs),
+                         running_std = torch.ones(1, nOutputs)}
 
   -- initializing gain to < 1 is recommended for LSTM batch norm.
-  p = {gain = torch.zeros(1, nOutputs):fill(0.1),
-       bias = torch.zeros(1, nOutputs)}
+  local p = {gain = torch.zeros(1, nOutputs):fill(0.1),
+             bias = torch.zeros(1, nOutputs)}
   table.insert(params, p)
 
   local function masked_batch_norm(params, x, mask, state, eps)

--- a/src/module/SoftAttention.lua
+++ b/src/module/SoftAttention.lua
@@ -13,9 +13,9 @@ return function(opt, params)
   local subjectFeatures = opt.subjectFeatures or 15
   local subjectChoices = opt.subjectChoices or 20
 
-  p = {W_att_subject = torch.zeros(1, 1, subjectFeatures),
-       W_att_h = torch.zeros(hiddenFeatures, subjectChoices),
-       b_att = torch.zeros(1, subjectChoices)}
+  local p = {W_att_subject = torch.zeros(1, 1, subjectFeatures),
+             W_att_h = torch.zeros(hiddenFeatures, subjectChoices),
+             b_att = torch.zeros(1, subjectChoices)}
 
   if layerNormalization then
     local focus_ln_params = LayerNorm({nOutputs = subjectChoices})


### PR DESCRIPTION
Changing p from global to local in all modules.

In layer normalization, moving addition of eps inside sqrt to prevent undefined gradient at sqrt(0).