### PR TITLE
literally just removing a print statement

### DIFF
--- a/src/util.lua
+++ b/src/util.lua
@@ -46,7 +46,7 @@ local function getValue(v)
       return v
    end
 end
-print(getValue)
+
 function util.lt(a, b)
    return getValue(a) < getValue(b)
 end


### PR DESCRIPTION
There is a print statement in util.lua for some reason. I'm assuming it is superfluous, and it was causing me problems trying to require autograd in openresty, so I've removed it, making the smallest possible pull request. Is there a need for that print statement?